### PR TITLE
fix error causing kubernetes node to fail

### DIFF
--- a/infra/k8s-prod/ingress-srv.yaml
+++ b/infra/k8s-prod/ingress-srv.yaml
@@ -6,7 +6,6 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/use-regex: "true"
-    # nginx.ingress.kubernetes.io/enable-proxy-protocol: "true"  
 spec:
   rules:
     - host: www.microservice-ticketing-sale-app.shop
@@ -52,16 +51,8 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    # kubernetes.digitalocean.com/load-balancer-id: f55b4d90-a133b90813aea44a58e8c87df66bdf3d-4b1a29c40ff
     service.beta.kubernetes.io/do-loadbalancer-enable-proxy-protocol: 'true'
     service.beta.kubernetes.io/do-loadbalancer-hostname: 'www.microservice-ticketing-sale-app.shop'
-    # service.beta.kubernetes.io/do-loadbalancer-healthcheck-port: "80"
-    # service.beta.kubernetes.io/do-loadbalancer-healthcheck-protocol: "http"
-    # service.beta.kubernetes.io/do-loadbalancer-healthcheck-path: "/health"
-    # service.beta.kubernetes.io/do-loadbalancer-healthcheck-check-interval-seconds: "3"
-    # service.beta.kubernetes.io/do-loadbalancer-healthcheck-response-timeout-seconds: "5"
-    # service.beta.kubernetes.io/do-loadbalancer-healthcheck-unhealthy-threshold: "3"
-    # service.beta.kubernetes.io/do-loadbalancer-healthcheck-healthy-threshold: "5"
   labels:
     helm.sh/chart: ingress-nginx-2.0.3
     app.kubernetes.io/name: ingress-nginx


### PR DESCRIPTION
digital ocean nodes started failing due to insufficient storage. Investiagted issue using the nodes condition and increasing disk, CPU and RAM storage effectively and re- deployed services to direct service to multiple servers and reduce node workload. 